### PR TITLE
Make `pageDescription` optional in Yaml frontmatter and add some tutorials

### DIFF
--- a/bindings/GrayMatter.res
+++ b/bindings/GrayMatter.res
@@ -1,6 +1,6 @@
 type pageContent = {
   title: string,
-  pageDescription: string,
+  pageDescription: option<string>,
 }
 
 type output = {data: pageContent, content: string}
@@ -8,5 +8,6 @@ type output = {data: pageContent, content: string}
 @module("gray-matter") external matter: string => output = "default"
 
 let forceInvalidException: JsYaml.forceInvalidException<pageContent> = c => {
-  let _ = (Js.String.length(c.title), Js.String.length(c.pageDescription))
+  let length = Js.Option.getWithDefault("", c.pageDescription) |> Js.String.length
+  let _ = (Js.String.length(c.title), length)
 }

--- a/bindings/GrayMatter.resi
+++ b/bindings/GrayMatter.resi
@@ -1,6 +1,6 @@
 type pageContent = {
   title: string,
-  pageDescription: string,
+  pageDescription: option<string>,
 }
 
 type output = {data: pageContent, content: string}

--- a/components/TitleHeading.res
+++ b/components/TitleHeading.res
@@ -11,51 +11,62 @@ module Large = {
   @react.component
   let make = (
     ~title,
-    ~pageDescription,
+    ~pageDescription: option<string>=?,
     ~marginTop="",
     ~marginBottom="",
     ~addMaxWidth=false,
     ~addBottomBar=false,
     ~callToAction=?,
     (),
-  ) => <>
-    // TODO: make addBottomBar and callToAction mutually exclusive
-    // TODO: consider whether to use a container component
-    <div
-      className={switch addMaxWidth {
-      | true => "max-w-7xl"
-      | false => ""
-      } ++ " mx-auto py-16 px-4 sm:py-24 sm:px-6 lg:px-8"}>
-      <div className="text-center">
-        <h1
-          className={marginTop ++ " text-4xl font-extrabold text-gray-900 sm:text-5xl sm:tracking-tight lg:text-6xl"}>
-          {s(title)}
-        </h1>
-        <p className="max-w-xl mt-5 mx-auto text-xl text-gray-500"> {s(pageDescription)} </p>
-        {switch callToAction {
-        | Some(callToAction) =>
-          <div className="text-center mt-7">
-            <Link href=callToAction.url>
-              <a
-                className="justify-center inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-orangedark hover:bg-orangedarker focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orangedarker">
-                {s(callToAction.label)}
-              </a>
-            </Link>
-          </div>
-        | None => <> </>
-        }}
+  ) => {
+    let descr = switch pageDescription {
+    | Some(d) => <p className="max-w-xl mt-5 mx-auto text-xl text-gray-500"> {s(d)} </p>
+    | None => React.null
+    }
+    <>
+      // TODO: make addBottomBar and callToAction mutually exclusive
+      // TODO: consider whether to use a container component
+      <div
+        className={switch addMaxWidth {
+        | true => "max-w-7xl"
+        | false => ""
+        } ++ " mx-auto py-16 px-4 sm:py-24 sm:px-6 lg:px-8"}>
+        <div className="text-center">
+          <h1
+            className={marginTop ++ " text-4xl font-extrabold text-gray-900 sm:text-5xl sm:tracking-tight lg:text-6xl"}>
+            {s(title)}
+          </h1>
+          descr
+          {switch callToAction {
+          | Some(callToAction) =>
+            <div className="text-center mt-7">
+              <Link href=callToAction.url>
+                <a
+                  className="justify-center inline-flex items-center px-4 py-2 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-orangedark hover:bg-orangedarker focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orangedarker">
+                  {s(callToAction.label)}
+                </a>
+              </Link>
+            </div>
+          | None => <> </>
+          }}
+        </div>
       </div>
-    </div>
-    {switch addBottomBar {
-    | true => <hr className={"bg-orangedark h-3 " ++ marginBottom} />
-    | false => React.null
-    }}
-  </>
+      {switch addBottomBar {
+      | true => <hr className={"bg-orangedark h-3 " ++ marginBottom} />
+      | false => React.null
+      }}
+    </>
+  }
 }
 
 module MarkdownMedium = {
   @react.component
-  let make = (~title, ~pageDescription) =>
+  let make = (~title, ~pageDescription=?) => {
+    let descr = switch pageDescription {
+    | Some(d) => <p className="mt-8 text-xl text-gray-500 leading-8"> {s(d)} </p>
+    | None => React.null
+    }
+
     <SectionContainer.MediumCentered2>
       <h1>
         <span
@@ -63,6 +74,7 @@ module MarkdownMedium = {
           {s(title)}
         </span>
       </h1>
-      <p className="mt-8 text-xl text-gray-500 leading-8"> {s(pageDescription)} </p>
+      descr
     </SectionContainer.MediumCentered2>
+  }
 }

--- a/components/TitleHeading.resi
+++ b/components/TitleHeading.resi
@@ -7,7 +7,7 @@ module Large: {
   @react.component
   let make: (
     ~title: string,
-    ~pageDescription: string,
+    ~pageDescription: string=?,
     ~marginTop: string=?,
     ~marginBottom: string=?,
     ~addMaxWidth: bool=?,
@@ -19,5 +19,5 @@ module Large: {
 
 module MarkdownMedium: {
   @react.component
-  let make: (~title: string, ~pageDescription: string) => React.element
+  let make: (~title: string, ~pageDescription: string=?) => React.element
 }

--- a/data/tutorials/a_first_hour_with_ocaml/a_first_hour_with_ocaml.md
+++ b/data/tutorials/a_first_hour_with_ocaml/a_first_hour_with_ocaml.md
@@ -1,0 +1,890 @@
+---
+title: A first hour with OCaml
+---
+You may follow along with this tutorial with just a basic OCaml installation,
+as described in [Up and Running](up_and_running.html).
+
+Alternatively, you may follow almost all of it by running OCaml in your browser
+using [TryOCaml](http://try.ocamlpro.com), with no installation required.
+
+## Running OCaml programs
+
+To try small OCaml expressions, you can use an interactive top level, or REPL
+(Read-Eval-Print Loop). The `ocaml` command provides a basic top level (you
+should install `rlwrap` through your system package manager and run `rlwrap
+ocaml` instead to get history navigation.)
+
+The alternative REPL [utop](https://github.com/ocaml-community/utop) may be installed
+through [opam](/docs/install.html#OPAM) or your system package manager. It has
+the same basic interface but is much more convenient to use (history
+navigation, auto-completion, etc).
+
+Use `;;` to indicate that you've finished entering each expression and prompt
+OCaml to evaluate it. We run OCaml and evaluate a simple expression:
+
+```console
+        OCaml version {{! get LATEST_OCAML_VERSION !}}
+
+# 50 * 50;;
+- : int = 2500
+```
+
+This is how it looks using `utop`:
+
+```console
+───────┬─────────────────────────────────────────────────────────────┬────
+       │ Welcome to utop version 2.7.0 (using OCaml version {{! get LATEST_OCAML_VERSION !}})! │     
+       └─────────────────────────────────────────────────────────────┘     
+
+Type #utop_help for help about using utop.
+
+─( 10:12:16 )─< command 0 >───────────────────────────────────────────────
+utop # 50 * 50;;
+- : int = 2500
+```
+
+The in-browser [TryOCaml](http://try.ocamlpro.com) has a similar interface.
+
+The examples in this tutorial can be typed in by hand, or copied into `ocaml`,
+`utop` or TryOCaml with copy and paste. Alternatively, we may type into a file,
+and load its contents directly with the `#use` directive:
+
+```console
+$ ocaml
+        OCaml version {{! get LATEST_OCAML_VERSION !}}
+
+# #use "program.ml"
+```
+
+Note that `#use` is not part of the OCaml language proper; it is an instruction
+to the OCaml top level only.
+
+## Expressions
+
+Our phrase `50 * 50` was an expression, which evaluated to `2500`. OCaml told
+us that the type was `int`, an integer (every expression in OCaml has a type).
+To avoid repetition, we can give a name to our number:
+
+```ocaml
+# let x = 50 ;;
+x * x;;
+```
+
+Note that this is not a variable as in languages like C and Python. Its value
+cannot be changed. We can write it all in one go using `let` ... `in` ...:
+
+```ocaml
+# let x = 50 in x * x;;
+```
+
+Of course, we can have multiple names:
+
+```ocamltop
+let a = 1 in
+let b = 2 in
+  a + b;;
+```
+
+Note that this is still just one expression. We can define a function to do the
+job for any number:
+
+```ocamltop
+let square x = x * x;;
+
+square 50;;
+```
+
+This says that `square` is a function with one argument, namely `x`, and that
+the result of the function is the result of evaluating the expression `x * x`
+with the given value associated with `x`. Here is another function, this time
+using the comparison operator `=` to test for even-ness:
+
+```ocamltop
+let square_is_even x =
+  square x mod 2 = 0;;
+
+square_is_even 50;;
+
+square_is_even 3;;
+```
+
+Notice the type OCaml infers for the function.
+
+A function may take multiple
+arguments. Unlike in imperative languages, they are written without parentheses
+and commas. We shall explain why later.
+
+```ocamltop
+let ordered a b c =
+  a <= b && b <= c;;
+
+ordered 1 1 2;;
+```
+
+We can work with floating-point numbers too, but we must write `+.`, for
+example, instead of just `+`:
+
+```ocamltop
+let average a b =
+  (a +. b) /. 2.0;;
+```
+
+This is rather unusual. In other languages (such as C) integers get promoted to
+floating point values in certain circumstances. For example if you write `1 +
+2.5` then the first argument (which is an integer) is promoted to a floating
+point number, and the result is also a floating point number.
+
+OCaml never does implicit casts like this. In OCaml, `1 + 2.5` is a type error.
+The `+` operator in OCaml requires two integers as arguments, and here we're
+giving it an integer and a floating point number, so it reports this error:
+
+```ocamltop
+1 + 2.5;;
+```
+
+OCaml doesn't promote integers to floating point numbers automatically so this
+is also an error:
+
+```ocamltop
+1 +. 2.5
+```
+
+What if you actually want to add an integer and a floating point number
+together? (Say they are stored as `i` and `f`). In OCaml you need to
+explicitly cast:
+
+```ocaml
+float_of_int i +. f
+```
+
+The `float_of_int` function takes an `int` and returns a `float`.
+
+You might think that these explicit casts are ugly, time-consuming even, but
+there are several arguments in their favour. Firstly, OCaml needs this explicit
+casting to be able to work out types automatically, which is a wonderful
+time-saving feature. Secondly, if you've spent time debugging C programs you'll
+know that (a) implicit casts cause errors which are hard to find, and (b) much
+of the time you're sitting there trying to work out where the implicit casts
+happen. Making the casts explicit helps you in debugging.  Thirdly, some casts
+are actually expensive operations. We do ourselves no favours by hiding them.
+
+## Recursive functions
+
+A recursive function is one which uses itself in its own definition. An OCaml
+function isn't recursive unless you explicitly say so by using `let rec`
+instead of just `let`. Here's an example of a recursive function:
+
+```ocamltop
+let rec range a b =
+  if a > b then []
+  else a :: range (a + 1) b;;
+
+let digits = range 0 9;;
+```
+
+We have used OCaml's `if` ... `then` ... `else` ... construct to test a
+condition and choose a path of evaluation. Notice that, like everything else in
+OCaml, it is an expression not a statement. The result of evaluating the whole
+expression is either the result of evaluating the `then` part or the `else`
+part.
+
+The only difference between `let` and `let rec` is in the scoping of the
+function name. If the above function had been defined with just `let`, then the
+call to `range` would have tried to look for an existing (previously defined)
+function called `range`, not the currently-being-defined function.
+
+## Types
+The basic types in OCaml are:
+
+```text
+OCaml type  Range
+
+int         63-bit signed int on 64-bit processors, or 31-bit signed int on
+            32-bit processors
+float       IEEE double-precision floating point, equivalent to C's double
+bool        A boolean, written either 'true' or 'false'
+char        An 8-bit character
+string      A string (sequence of 8 bit chars)
+```
+
+OCaml provides a `char` type which is used for simple 8-bit characters, written
+`'x'` for example. There are [comprehensive Unicode
+libraries](https://github.com/yoriyuki/Camomile) which provide more extensive
+functionality for text management.
+
+Strings are not just lists of characters. They have their own, more
+efficient internal representation. Strings are immutable.
+
+When we type our expressions into the OCaml top level, OCaml prints the type:
+
+```ocamltop
+1 + 2;;
+
+1.0 +. 2.0;;
+
+false;;
+
+'c';;
+
+"Help me!";;
+
+```
+
+Each expression has one and only one type.
+
+OCaml works out types automatically so you will rarely need to explicitly write
+down the type of your functions. However, OCaml often prints out what it infers
+are the types of your functions, so you need to know the syntax. For a function
+`f` which takes arguments `arg1`, `arg2`, ... `argn`, and returns type
+`rettype`, the compiler will print:
+
+```ocaml
+f : arg1 -> arg2 -> ... -> argn -> rettype
+```
+
+The arrow syntax looks strange now but later you'll see why it was chosen. Our
+function `average` which takes two floats and returns a float has type:
+
+```ocaml
+average : float -> float -> float
+```
+
+The OCaml standard `int_of_char` casting function:
+
+```ocaml
+int_of_char : char -> int
+```
+
+We can now look at some of the properties which distinguish OCaml from other
+languages:
+
+- OCaml is a strongly statically typed language. This means each expression has
+  a type, and only one type, and it is determined before the program is run.
+
+- OCaml uses type inference to work out (infer) the types, so you don't have
+  to. If you use the OCaml top level, then OCaml will tell you its inferred
+  type for your function.
+
+- OCaml doesn't do any implicit conversion of types. If you want a floating
+  point number, you have to write `2.0` because `2` is an integer. OCaml does
+  no automatic conversion between int and floats or any other type. As a
+  side-effect of type inference in OCaml, functions (including operators) can't
+  have overloaded definitions.
+
+## Pattern matching
+
+Instead of using one or more `if` ... `then` ... `else` ... constructs to make
+choices in OCaml programs, we can use the `match` keyword to match on multiple
+possible values. Consider the factorial function:
+
+```ocamltop
+let rec factorial n =
+  if n <= 1 then 1 else n * factorial (n - 1);;
+```
+
+We may write it using pattern matching instead:
+
+```ocamltop
+let rec factorial n =
+  match n with
+  | 0 | 1 -> 1
+  | x -> x * factorial (x - 1);;
+```
+
+Equally, we could use the pattern `_` which matches anything, and write:
+
+```ocamltop
+let rec factorial n =
+  match n with
+  | 0 | 1 -> 1
+  | _ -> n * factorial (n - 1);;
+```
+
+In fact, we may simplify further with the `function` keyword which introduces
+pattern-matching directly:
+
+```ocamltop
+let rec factorial = function
+  | 0 | 1 -> 1
+  | n -> n * factorial (n - 1);;
+```
+
+We will use pattern matching more extensively as we introduce more complicated
+data structures.
+
+## Lists
+
+Lists are a common compound data type in OCaml. They are ordered collections of
+elements of like type. Here are some lists:
+
+```ocamltop
+[];;
+
+[1; 2; 3];;
+
+[false; false; true];;
+
+[[1; 2]; [3; 4]; [5; 6]];;
+```
+
+Each list can have a head (its first element) and a tail (the list of the rest
+of its elements).  There are two built-in operators on lists. The `::` or cons
+operator, adds one element to the front of a list. The `@` or append operator
+combines two lists:
+
+```ocamltop
+1 :: [2; 3];;
+
+[1] @ [2; 3];;
+```
+
+We can write functions which operate over lists by pattern matching:
+
+```ocamltop
+let rec total l =
+  match l with
+  | [] -> 0
+  | h :: t -> h + total t;;
+
+total [1; 3; 5; 3; 1];;
+```
+
+You can see how the pattern `h :: t` is used to deconstruct the list, naming
+its head and tail. If we omit a case, OCaml will notice and warn us:
+
+```ocamltop
+let rec total l =
+  match l with
+  | h :: t -> h + total t;;
+
+total [1; 3; 5; 3; 1];;
+```
+
+We shall talk about the "exception" which was caused by our ignoring the
+warning later. Consider now a function to find the length of a list:
+
+```ocamltop
+let rec length l =
+  match l with
+  | [] -> 0
+  | _ :: t -> 1 + length t;;
+```
+
+This function operates not just on lists of integers, but on any kind of list.
+This is indicated by the type, which allows its input to be `'a list`
+(pronounced alpha list).
+
+```ocamltop
+length [1; 2; 3];;
+
+length ["cow"; "sheep"; "cat"];;
+
+length [[]];;
+```
+
+Why is this? Because in the pattern `_ :: t` the head of the list is not
+inspected, so its type cannot be relevant. Such a function is called
+polymorphic. Here is another polymorphic function, our own version of the `@`
+operator for appending:
+
+```ocamltop
+let rec append a b =
+  match a with
+  | [] -> b
+  | h :: t -> h :: append t b;;
+```
+
+Can you see how it works? Notice that the memory for the second list is shared,
+but the first list is effectively copied. Such sharing is common when we use
+immutable data types (ones whose values cannot be changed).
+
+We might wish to apply a function to each element in a list, yielding a new
+one. We shall write a function `map` which is given another function as its
+argument - such a function is called "higher-order":
+
+```ocamltop
+let rec map f l =
+  match l with
+  | [] -> []
+  | h :: t -> f h :: map f t;;
+```
+
+Notice the type of the function `f` in parentheses as part of the whole type.
+This `map` function, given a function of type `'a -> 'b` and a list of `'a`s,
+will build a list of `'b'`s. Sometimes `'a` and `'b` might be the same type, of
+course. Here are some examples of using `map`:
+
+```ocamltop
+map total [[1; 2]; [3; 4]; [5; 6]];;
+map (fun x -> x * 2) [1; 2; 3];;
+```
+
+(The syntax `fun` ... `->` ... is used to build a function without a name - one
+we will only use in one place in the program.)
+
+We need not give a function all its arguments at once. This is called partial
+application. For example:
+
+```ocamltop
+let add a b = a + b;;
+add;;
+let f = add 6;;
+f 7;;
+```
+
+Look at the types of `add` and `f` to see what is going on. We can use partial
+application to add to each item of a list:
+
+```ocamltop
+map (add 6) [1; 2; 3];;
+```
+
+Indeed we can use partial application of our `map` function to map over lists
+of lists:
+
+```ocamltop
+map (map (fun x -> x * 2)) [[1; 2]; [3; 4]; [5; 6]];;
+```
+
+## Other built-in types
+
+We have seen basic data types like `int`, and our first compound data type, the
+list. There are two more ways compound data types of interest. First we have
+tuples, which are fixed length collections of elements of any type:
+
+```ocamltop
+let t = (1, "one", '1')
+```
+
+Notice how the type is written. Records are like tuples, but they have named
+elements:
+
+```ocamltop
+type person =
+  {first_name : string;
+   surname : string;
+   age : int};;
+
+let frank =
+  {first_name = "Frank";
+   surname = "Smith";
+   age = 40};;
+
+let s = frank.surname;;
+```
+
+Pattern-matching works on tuples and records too, of course.
+
+## Our own data types
+
+We can define new data types in OCaml with the `type` keyword:
+
+```ocamltop
+type colour = Red | Blue | Green | Yellow;;
+let l = [Red; Blue; Red];;
+```
+
+Each "type constructor", which must begin with a capital letter, can optionally
+carry data along with it:
+
+```ocamltop
+type colour =
+  | Red
+  | Blue
+  | Green
+  | Yellow
+  | RGB of int * int * int;;
+let l = [Red; Blue; RGB (30, 255, 154)];;
+```
+
+Data types may be polymorphic and recursive too. Here is an OCaml data type for
+a binary tree carrying any kind of data:
+
+```ocamltop
+type 'a tree =
+  | Lf
+  | Br of 'a tree * 'a * 'a tree;;
+
+let t = Br (Br (Lf, 1, Lf), 2, Br (Br (Lf, 3, Lf), 4, Lf));;
+```
+
+A `Lf` leaf holds no information, just like an empty list. A `Br` branch holds
+a left tree, a value of type `'a` and a right tree. Now we can write recursive
+and polymorphic functions over these trees, by pattern matching on our new
+constructors:
+
+```ocamltop
+let rec total t =
+  match t with
+  | Lf -> 0
+  | Br (l, x, r) -> total l + x + total r;;
+
+let rec flip t =
+  match t with
+  | Lf -> Lf
+  | Br (l, x, r) -> Br (flip r, x, flip l);;
+```
+
+Let's try our new functions out:
+
+```ocamltop
+let all = total t;;
+
+let flipped = flip t;;
+
+t = flip flipped;;
+```
+
+Notice that we do not need to explicitly free memory for such data structures
+when we no longer need it: OCaml is a garbage-collected language, and will free
+memory for data structures when they are no longer needed. In our example, once
+the boolean test `t = flip flipped` has been evaluated, the data structure
+`flip flipped` is not longer reachable by the rest of the program, and its
+memory may be reclaimed by the garbage collector.
+
+## Dealing with errors
+
+OCaml deals with exceptional situations in two ways. One is to use *exceptions*,
+which may be defined in roughly the same way as types:
+
+```ocamltop
+exception E;;
+
+exception E2 of string;;
+```
+
+An exception is raised like this:
+
+```ocamltop
+let f a b =
+  if b = 0 then raise (E2 "division by zero") else a / b;;
+```
+
+An exception may be handled with pattern matching:
+
+```ocamltop
+try f 10 0 with E2 _ -> 0;;
+```
+
+When an exception is not handled, it is printed at the top level:
+
+```ocamltop
+f 10 0;;
+```
+
+The other way to deal with exceptional situations in OCaml is by returning a
+value of a type which can represent either the correct result or an error, for
+example the built-in polymorphic `option` type, which is defined as:
+
+```ocaml
+type 'a option = None | Some of 'a
+```
+
+So we may write:
+
+```ocamltop
+let f a b =
+  if b = 0 then None else Some (a / b)
+```
+
+We can use exception handling to build an option-style function from one which
+raises an exception, the built-in `List.find` function (which finds the first
+element matching a given boolean test):
+
+```ocamltop
+let list_find_opt p l =
+  try Some (List.find p l) with
+    Not_found -> None;;
+```
+
+As an alternative, we can use an extended form of our usual `match` expression,
+to match both values and catch exceptions:
+
+```ocamltop
+let list_find_opt p l =
+  match List.find p l with
+  | v -> Some v
+  | exception Not_found -> None;;
+```
+
+## Imperative OCaml
+
+OCaml is not just a functional language: it supports imperative programming
+too. OCaml programmers tend to use imperative features sparingly, but almost
+all OCaml programmers use them sometimes. What happens if you want a variable
+that you can assign to and change throughout your program? You need to use a
+*reference*.
+
+Here's how we create a reference to an integer in OCaml:
+
+```ocamltop
+let r = ref 0;;
+```
+
+This reference is currently storing the integer zero. Let's put something
+else into it (assignment):
+
+```ocamltop
+r := 100;;
+```
+
+And let's find out what the reference contains now:
+
+```ocamltop
+!r;;
+```
+
+So the `:=` operator is used to assign to references, and the `!` operator
+dereferences to get the contents.
+
+References have their place, but you may find that you don't use them very
+often. Much more often you'll be using `let` ... `=` ... `in` ... to name local
+expressions in your function definitions.
+
+We can combine multiple imperative operations with `;`. For example, here is a
+function to swap the contents of two references of like type:
+
+```ocamltop
+let swap a b =
+  let t = !a in
+    a := !b;
+    b := t;;
+```
+
+Notice the function return type is `unit`. There is exactly one thing of type
+unit, and it is written `()`. We use unit to call a function which needs no
+other argument, and is only used for its imperative side effect. For example:
+
+```ocamltop
+let print_number n =
+  print_string (string_of_int n);
+  print_newline ();;
+```
+
+We can look at the type of the built-in function `print_newline` by typing its
+name without applying the unit argument:
+
+```ocamltop
+print_newline;;
+```
+
+The usual imperative looping constructs are available. Here is a `for` loop:
+
+```ocamltop
+let table n =
+  for row = 1 to n do
+    for column = 1 to n do
+      print_string (string_of_int (row * column));
+      print_string " "
+    done;
+    print_newline ()
+  done;;
+
+let () = table 10;;
+```
+
+Here is a `while` loop, used to write a function to calculate the power of
+two larger or equal to a given number:
+
+```ocamltop
+let smallest_power_of_two x =
+  let t = ref 1 in
+    while !t < x do
+      t := !t * 2
+    done;
+    !t;;
+```
+
+In addition to references, the imperative part of OCaml has arrays of items of
+like type, whose elements can be accessed or updated in constant time:
+
+```ocamltop
+let arr = [|1; 2; 3|];;
+arr.(0);;
+arr.(0) <- 0;;
+arr;;
+```
+
+Records may have mutable fields too, which must be marked in the type:
+
+```ocamltop
+type person =
+  {first_name : string;
+   surname : string;
+   mutable age : int};;
+
+let birthday p =
+  p.age <- p.age + 1;;
+```
+
+## The Standard Library
+
+OCaml comes with a library of useful modules which are available anywhere OCaml
+is. For example there are standard libraries for functional data structures
+(such as maps and sets) and imperative data structures (such as hash tables),
+and for interacting with the operating system. We use them by writing the module, followed by a
+full stop, followed by the name of the function. Here are some functions from
+the `List` module:
+
+```ocamltop
+List.concat [[1; 2; 3]; [4; 5; 6]; [7; 8; 9]];;
+List.filter (( < ) 10) [1; 4; 20; 10; 9; 2];;
+List.sort compare [1; 6; 2; 2; 3; 56; 3; 2];;
+```
+
+The `Printf` module provides type-checked printing facilities, so we know at
+compile-time that the printing will work:
+
+```ocamltop
+let print_length s =
+  Printf.printf "%s has %i characters\n" s (String.length s);;
+ 
+List.iter print_length ["one"; "two"; "three"];;
+```
+
+You can find the full list of standard library modules in the
+[manual](/releases/latest/manual.html).
+
+## A module from OPAM
+
+Apart from the standard library, a much wider range of modules are available
+through the OCaml Package Manager, opam. You must have OCaml on your computer
+to follow the tutorial from now on, not just TryOCaml.
+
+For these examples we're going to use module called `Graphics` which can be
+installed with `opam install graphics` and the `ocamlfind` program installed
+with `opam install ocamlfind`. The `Graphics` module is a very simple
+cross-platform Graphics system which was once part of OCaml itself. Now it's
+available separately through OPAM.
+
+If we want to use the functions in `Graphics` there are two ways we can
+do it. Either at the start of our program we have the `open Graphics`
+declaration. Or we prefix all calls to the functions like this:
+`Graphics.open_graph`.
+
+To use `Graphics` in the top level, you must first load the library with
+
+```ocaml
+# #use "topfind";;
+- : unit = ()
+Findlib has been successfully loaded. Additional directives:
+...
+  #require "package";;      to load a package
+...
+
+- : unit = ()
+# #require "graphics";;
+/Users/me/.opam/4.12.0/lib/graphics: added to search path
+/Users/me/.opam/4.12.0/lib/graphics/graphics.cma: loaded
+```
+
+A couple of examples should make this clear. (The two examples draw different
+things - try them out). Note the first example uses `open` to open the Graphics
+module then calls `open_graph` and the second one uses `Graphics.open_graph`
+directly.
+
+```ocaml
+open Graphics;;
+
+open_graph " 640x480";;
+
+for i = 12 downto 1 do
+  let radius = i * 20 in
+    set_color (if i mod 2 = 0 then red else yellow);
+    fill_circle 320 240 radius
+done;;
+
+read_line ();;
+```
+
+```ocaml
+Random.self_init ();;
+
+Graphics.open_graph " 640x480";;
+
+let rec iterate r x_init i =
+  if i = 1 then x_init else
+    let x = iterate r x_init (i - 1) in
+      r *. x *. (1.0 -. x);;
+
+for x = 0 to 639 do
+  let r = 4.0 *. (float_of_int x) /. 640.0 in
+  for i = 0 to 39 do
+    let x_init = Random.float 1.0 in
+    let x_final = iterate r x_init 500 in
+    let y = int_of_float (x_final *. 480.) in
+      Graphics.plot x y
+  done
+done;;
+
+read_line ();;
+```
+
+You should copy and paste these examples into OCaml piece by piece, each piece
+being ended by a  `;;`.
+
+## Compiling OCaml programs
+
+So far we have been using only the OCaml top level. Now we will compile OCaml
+programs into fast stand-alone executables. Consider the following program,
+saved as "helloworld.ml"
+
+```ocaml
+print_endline "Hello, World!"
+```
+
+(Notice there is no need to write `;;` since we are not using the top level).
+We may compile it like this:
+
+```ocaml
+ocamlopt -o helloworld helloworld.ml
+```
+
+Now our current directory has four more files. The files `helloworld.cmi`,
+`helloworld.cmo`, and `helloworld.o` are left over from the compilation
+process. The file `helloworld` is our executable:
+
+```ocaml
+$ ./helloworld
+Hello, World!
+$
+```
+
+If we have more than one file, we list them all. Here is an example, defined in
+its own file `data.ml` with a corresponding `data.mli` interface, and a main
+file `main.ml` which uses it.
+
+```ocaml
+data.ml:
+
+let to_print = "Hello, World!"
+```
+
+```ocaml
+data.mli:
+
+val to_print : string
+```
+
+```ocaml
+main.ml:
+
+print_endline Data.to_print
+```
+
+We can compile it like this:
+
+```console
+ocamlopt -o main data.mli data.ml main.ml
+```
+
+Most users of OCaml do not call the compiler directly. They use one of the
+[build systems](/learn/tutorials/compiling_ocaml_projects.html) to manage
+compilation for them.
+
+## Where next?
+
+This quick tour should have given you a little taste of OCaml and why you might
+like to explore it further. Elsewhere on [ocaml.org](/index.html) there are
+pointers to [books on OCaml](/learn/books.html) and
+[other tutorials](/learn/tutorials/index.html).

--- a/data/tutorials/a_first_hour_with_ocaml/dune
+++ b/data/tutorials/a_first_hour_with_ocaml/dune
@@ -1,0 +1,2 @@
+(mdx
+    (files a_first_hour_with_ocaml.md))

--- a/data/tutorials/a_first_hour_with_ocaml/dune-project
+++ b/data/tutorials/a_first_hour_with_ocaml/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.7)
+(using mdx 0.1)

--- a/data/tutorials/debug/debug.md
+++ b/data/tutorials/debug/debug.md
@@ -1,0 +1,276 @@
+---
+title: Debuggings
+---
+
+This tutorial presents two techniques for debugging OCaml programs:
+
+* [Tracing functions calls](#Tracingfunctionscallsinthetoplevel),
+  which works in the interactive toplevel.
+* The [OCaml debugger](#The-OCaml-debugger), which allows analysing programs
+  compiled with `ocamlc`.
+
+## Tracing functions calls in the toplevel
+
+The simplest way to debug programs in the toplevel is to follow the function
+calls, by “tracing” the faulty function:
+
+```ocamltop
+let rec fib x = if x <= 1 then 1 else fib (x - 1) + fib (x - 2);;
+#trace fib;;
+fib 3;;
+#untrace fib;;
+```
+
+###  Polymorphic functions
+
+A difficulty with polymorphic functions is that the output of the trace system
+is not very informative in case of polymorphic arguments and/or results.
+Consider a sorting algorithm (say bubble sort):
+
+```ocamltop
+let exchange i j v =
+  let aux = v.(i) in
+    v.(i) <- v.(j);
+    v.(j) <- aux
+
+let one_pass_vect fin v =
+  for j = 1 to fin do
+    if v.(j - 1) > v.(j) then exchange (j - 1) j v
+  done
+
+let bubble_sort_vect v =
+  for i = Array.length v - 1 downto 0 do
+    one_pass_vect i v
+  done;;
+
+let q = [|18; 3; 1|];;
+
+#trace one_pass_vect;;
+bubble_sort_vect q;;
+```
+
+The function `one_pass_vect` being polymorphic, its vector argument is printed
+as a vector containing polymorphic values, `[|<poly>; <poly>; <poly>|]`, and
+thus we cannot properly follow the computation.
+
+A simple way to overcome this problem is to define a monomorphic version of the
+faulty function. This is fairly easy using a *type constraint*.  Generally
+speaking, this allows a proper understanding of the error in the definition of
+the polymorphic function. Once this has been corrected, you just have to
+suppress the type constraint to revert to a polymorphic version of the
+function.
+
+For our sorting routine, a single type constraint on the argument of the
+`exchange` function warranties a monomorphic typing, that allows a proper trace
+of function calls:
+
+```ocamltop
+let exchange i j (v : int array) =    (* notice the type constraint *)
+  let aux = v.(i) in
+    v.(i) <- v.(j);
+    v.(j) <- aux
+
+let one_pass_vect fin v =
+  for j = 1 to fin do
+    if v.(j - 1) > v.(j) then exchange (j - 1) j v
+  done
+
+let bubble_sort_vect v =
+  for i = Array.length v - 1 downto 0 do
+    one_pass_vect i v
+  done;;
+
+let q = [| 18; 3; 1 |];;
+
+#trace one_pass_vect;;
+bubble_sort_vect q;;
+```
+
+###  Limitations
+
+To keep track of assignments to data structures and mutable variables in a
+program, the trace facility is not powerful enough. You need an extra mechanism
+to stop the program in any place and ask for internal values: that is a
+symbolic debugger with its stepping feature.
+
+Stepping a functional program has a meaning which is a bit weird to define and
+understand. Let me say that we use the notion of *runtime events* that happen
+for instance when a parameter is passed to a function or when entering a
+pattern matching, or selecting a clause in a pttern matching. Computation
+progress is taken into account by these events, independently of the
+instructions executed on the hardware.
+
+Although this is difficult to implement, there exists such a debugger for OCaml
+under Unix: `ocamldebug`. Its use is illustrated in the next section.
+
+In fact, for complex programs, it is likely the case that the programmer will
+use explicit printing to find the bugs, since this methodology allows the
+reduction of the trace material: only useful data are printed and special
+purpose formats are more suited to get the relevant information, than what can
+be output automatically by the generic pretty-printer used by the trace
+mechanism.
+
+## The OCaml debugger
+
+We now give a quick tutorial for the OCaml debugger (`ocamldebug`).  Before
+starting, please note that `ocamldebug` does not work under native Windows
+ports of OCaml (but it runs under the Cygwin port).
+
+###  Launching the debugger
+
+Consider the following obviously wrong program written in the file
+`uncaught.ml`:
+
+```ocaml
+(* file uncaught.ml *)
+let l = ref []
+let find_address name = List.assoc name !l
+let add_address name address = l := (name, address) :: ! l
+
+let () =
+  add_address "IRIA" "Rocquencourt";;
+  print_string (find_address "INRIA"); print_newline ();;
+```
+
+At runtime, the program raises an uncaught exception `Not_found`.  Suppose we
+want to find where and why this exception has been raised, we can proceed as
+follows. First, we compile the program in debug mode:
+
+```
+ocamlc -g uncaught.ml
+```
+
+We launch the debugger:
+
+```
+ocamldebug a.out
+```
+
+Then the debugger answers with a banner and a prompt:
+
+```
+OCaml Debugger version 4.12.0
+
+(ocd)
+```
+
+###  Finding the cause of a spurious exception
+
+Type `r` (for *run*); you get
+
+```
+(ocd) r
+Loading program... done.
+Time : 12
+Program end.
+Uncaught exception: Not_found
+(ocd)
+```
+
+Self explanatory, isn't it? So, you want to step backward to set the program
+counter before the time the exception is raised; hence type in `b` as
+*backstep*, and you get
+
+```
+(ocd) b
+Time : 11 - pc : 15500 - module List
+143     [] -> <|b|>raise Not_found
+```
+
+The debugger tells you that you are in module `List`, inside a pattern matching
+on a list that already chose the `[]` case and is about to execute `raise
+Not_found`, since the program is stopped just before this expression (as
+witnessed by the `<|b|>` mark).
+
+But, as you know, you want the debugger to tell you which procedure calls the
+one from `List`, and also who calls the procedure that calls the one from
+`List`; hence, you want a backtrace of the execution stack:
+
+```
+(ocd) bt
+#0  Pc : 15500  List char 3562
+#1  Pc : 19128  Uncaught char 221
+```
+
+So the last function called is from module `List` at character 3562, that is:
+
+```ocaml
+let rec assoc x = function
+  | [] -> raise Not_found
+          ^
+  | (a,b)::l -> if a = x then b else assoc x l
+```
+
+The function that calls it is in module `Uncaught`, file `uncaught.ml` char
+221:
+
+```ocaml
+print_string (find_address "INRIA"); print_newline ();;
+                                  ^
+```
+
+To sum up: if you're developing a program you can compile it with the `-g`
+option, to be ready to debug the program if necessary. Hence, to find a
+spurious exception you just need to type `ocamldebug a.out`, then `r`, `b`, and
+`bt` gives you the backtrace.
+
+###  Getting help and info in the debugger
+
+To get more info about the current status of the debugger you can ask it
+directly at the toplevel prompt of the debugger; for instance:
+
+```
+(ocd) info breakpoints
+No breakpoint.
+
+(ocd) help break
+  1      15396  in List, character 3539
+break : Set breakpoint at specified line or function.
+Syntax: break function-name
+break @ [module] linenum
+break @ [module] # characternum
+```
+
+###  Setting break points
+
+Let's set up a breakpoint and rerun the entire program from the
+beginning (`(g)oto 0` then `(r)un`):
+
+```ocaml
+(ocd) break @Uncaught 9
+Breakpoint 3 at 19112 : file Uncaught, line 9 column 34
+
+(ocd) g 0
+Time : 0
+Beginning of program.
+
+(ocd) r
+Time : 6 - pc : 19112 - module Uncaught
+Breakpoint : 1
+9 add "IRIA" "Rocquencourt"<|a|>;;
+```
+
+Then, we can step and find what happens when `find_address` is about to be
+called
+
+```
+(ocd) s
+Time : 7 - pc : 19012 - module Uncaught
+5 let find_address name = <|b|>List.assoc name !l;;
+
+(ocd) p name
+name : string = "INRIA"
+
+(ocd) p !l
+$1 : (string * string) list = ["IRIA", "Rocquencourt"]
+(ocd)
+```
+
+Now we can guess why `List.assoc` will fail to find "INRIA" in the list...
+
+###  Using the debugger under Emacs
+
+Under Emacs you call the debugger using `ESC-x` `ocamldebug a.out`. Then Emacs
+will send you directly to the file and character reported by the debugger, and
+you can step back and forth using `ESC-b` and `ESC-s`, you can set up break
+points using `CTRL-X space`, and so on...

--- a/res_pages/resources/ResourcesTutorialTemplate.res
+++ b/res_pages/resources/ResourcesTutorialTemplate.res
@@ -9,17 +9,13 @@ type t = {contents: string}
 type props = {
   source: string,
   title: string,
-  pageDescription: string,
+  pageDescription: Js.Nullable.t<string>,
   tableOfContents: MarkdownPage.TableOfContents.t,
 }
 
 @react.component
 let make = (~source, ~title, ~pageDescription, ~tableOfContents) => {
   <>
-    <ConstructionBanner
-      figmaLink=`https://www.figma.com/file/36JnfpPe1Qoc8PaJq8mGMd/V1-Pages-Next-Step?node-id=430%3A21054`
-      playgroundLink=`/play/resources/installocaml`
-    />
     // TODO: should this have a constrained width? what does tailwind do?
     <MainContainer.None>
       <div className="grid grid-cols-9 bg-white">
@@ -39,7 +35,7 @@ let contentEn = {
   contents: `Contents`,
 }
 
-type pageContent = {title: string, pageDescription: string}
+type pageContent = {title: string, pageDescription: option<string>}
 
 @module("js-yaml") external load: (string, ~options: 'a=?, unit) => pageContent = "load"
 
@@ -72,7 +68,10 @@ let getStaticProps = ctx => {
     let props = {
       source: res.contents,
       title: parsed.data.title,
-      pageDescription: parsed.data.pageDescription,
+      pageDescription: switch parsed.data.pageDescription {
+      | None => Js.Nullable.null
+      | Some(v) => Js.Nullable.return(v)
+      },
       tableOfContents: {
         contents: "Contents",
         toc: res.toc,


### PR DESCRIPTION
Since the values defined in props must be JSON serialisable, we need to do an explicit conversion to Js.Nullable at the component bit.
    
xref: https://dev.to/ryyppy/reason-records-nextjs-undefined-and-getstaticprops-5d46
    
(Also turn off the Figma playground link in the tutorial template)
