### PR TITLE
Implement makefile clean commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,6 @@ clean:
 	-rm -rf .next
 	-rm -rf out
 
-.PHONY: clean-cache
-clean-cache:
-
 .PHONY: distclean
 distclean: clean clean-cache
 	-($(YARN) unlink ood && cd vendor/ood && $(YARN) unlink)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean:
 	-rm -rf out
 
 .PHONY: distclean
-distclean: clean clean-cache
+distclean: clean
 	-($(YARN) unlink ood && cd vendor/ood && $(YARN) unlink)
 	-rm -rf vendor
 	-rm -rf node_modules

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,19 @@ serve: build
 
 .PHONY: clean
 clean:
-	$(BSB) -clean
+	-$(BSB) -clean
+	-$(ESY) dune clean
+	-rm -f .merlin
+	-rm -rf .next
+	-rm -rf out
+
+.PHONY: clean-cache
+clean-cache:
+
+.PHONY: distclean
+distclean: clean clean-cache
+	-($(YARN) unlink ood && cd vendor/ood && $(YARN) unlink)
+	-rm -rf vendor
+	-rm -rf node_modules
+	-rm -rf _esy
+	-rm -f yarn-error.log


### PR DESCRIPTION
Issue #199

CHANGELOG:
- Implements 2 Makefile targets
  - `clean` removes build artifacts
  - `distclean` is effectively `git clean -Xdi`
  - NOTE: The linked issue originally called for 3 targets, however, we determined that we do not have any use for `clean-cache`, so it has not been included as part of this PR.