### PR TITLE
Doc yarn version, remove esy version spec in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL=/bin/bash
 NVM=source $$NVM_DIR/nvm.sh && nvm
+# Yarn version specified here because it can't
+# bootstrap itself as a devDependency.
 YARN=$(NVM) use && npx yarn@1.22
-ESY=$(NVM) use && npx esy@0.6.8
+ESY=$(NVM) use && npx esy
 BSB=$(NVM) use && npx bsb
 
 .PHONY: dev

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@tailwindcss/typography": "^0.4.0",
     "autoprefixer": "^10.2.5",
     "concurrently": "^6.1.0",
+    "esy": "^0.6.8",
     "gray-matter": "^4.0.3",
     "http-server": "^0.12.3",
     "js-yaml": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,6 +1030,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+esy@0.6.8:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/esy/-/esy-0.6.8.tgz#77489e479f2efc912eac571e1ef8631c68c8d865"
+  integrity sha512-tSNYVoLV0ps3hVPG0kaJCdaB0cQKwPMuydPqZQ+VsyfA7TMBLIVv1hoqoVf6e6slyyCepPu2KMDApL2H2smlew==
+
 etag@1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"


### PR DESCRIPTION
Follow up to: https://github.com/ocaml/v3.ocaml.org/pull/332#discussion_r634372762

CHANGES:
- Clarify docs, fix versioning in Makefile.