### PR TITLE
rename search text to 'search ocaml.org'

### DIFF
--- a/src/GlobalData.res
+++ b/src/GlobalData.res
@@ -140,7 +140,7 @@ let headerContentEn: HeaderNavigation.content = {
       navContentEn.communitySection.archive,
     ],
   },
-  search: `Search`,
+  search: `Search ocaml.org`,
   openMenu: `Open menu`,
 }
 


### PR DESCRIPTION
This ensures that the site name is referenced in the toplevel bar

Closes #341