### PR TITLE
Add deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# This file aims to stay close to its upstream version: https://github.com/github/gitignore/blob/master/Node.gitignore
+# Yarn
+yarn-error.log
+
+# macOS
+.DS_Store
+
+# Vim
+*.swp
+*.swo
+
+# Node
+node_modules/
+/.nvmrc
+
+# Next.js
+.next/
+out
+
+# ReScript
+.bsb.lock
+.merlin
+/lib/
+/src/*.js
+/vendor/ood/src/*.js
+/pages/**/*.js
+!/pages/_app.js
+
+# Editor
+.github/
+.vscode/
+README.md
+Makefile
+LIVE_README.md
+CONTRIBUTING.md
+
+# Docker
+.dockerignore
+Dockerfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ocaml/v3.ocaml.org:latest
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,24 +6,22 @@ RUN apk add --update --no-cache python g++ make
 WORKDIR /app
 
 COPY package.json yarn.lock ./
+
 RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM node:14-alpine AS builder
+
 WORKDIR /app
+
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
+
 RUN yarn build
 
-# Production image, copy all the files and serve them
-FROM alpine:latest AS runner
+# Production image containing only the static files
+FROM alpine:latest AS data
 
-WORKDIR /app
-
-RUN apk add thttpd
+WORKDIR /data
 
 COPY --from=builder /app/out .
-
-EXPOSE 3000
-
-CMD ["thttpd", "-D", "-h", "0.0.0.0", "-p", "3000", "-d", "/app", "-l", "-", "-M", "60"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Install dependencies only when needed
+FROM node:14-alpine AS deps
+
+RUN apk add --update --no-cache python g++ make
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# Rebuild the source code only when needed
+FROM node:14-alpine AS builder
+WORKDIR /app
+COPY . .
+COPY --from=deps /app/node_modules ./node_modules
+RUN yarn build
+
+# Production image, copy all the files and serve them
+FROM alpine:latest AS runner
+
+WORKDIR /app
+
+RUN apk add thttpd
+
+COPY --from=builder /app/out .
+
+EXPOSE 3000
+
+CMD ["thttpd", "-D", "-h", "0.0.0.0", "-p", "3000", "-d", "/app", "-l", "-", "-M", "60"]

--- a/next.config.js
+++ b/next.config.js
@@ -11,20 +11,6 @@ const config = {
   // where urls without trailing slashes are redirected to their
   // counterparts with trailing slashes.
   trailingSlash: true,
-  // We observed this undocumented behavior on Vercel, so
-  // we are adding this rewrite to make the behavior explicit
-  // and ensure local development and Vercel deployments
-  // use the same rule.
-  async rewrites() {
-    return {
-      fallback: [
-        {
-          source: '/:path*',
-          destination: '/:path*/index.html',
-        },
-      ],
-    }
-  },
   // Might need to move this to nginx or other config,
   // if deployment moves from Vercel to Netlify
   async redirects() {

--- a/next.config.js
+++ b/next.config.js
@@ -4,12 +4,13 @@ const transpileModules = ["bs-platform"].concat(bsconfig["bs-dependencies"]);
 const withTM = require("next-transpile-modules")(transpileModules);
 
 const config = {
-  webpack: (config, options) => {
-    config.experiments = {
-      topLevelAwait: true,
-    }
-    return config
-  },
+  // By default Next.js will redirect urls with trailing slashes
+  // to their counterpart without a trailing slash.
+  // For example /about/ will redirect to /about.
+  // `trailingSlash: true` configures this behavior to act the opposite way,
+  // where urls without trailing slashes are redirected to their
+  // counterparts with trailing slashes.
+  trailingSlash: true,
   // We observed this undocumented behavior on Vercel, so
   // we are adding this rewrite to make the behavior explicit
   // and ensure local development and Vercel deployments

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "next:debug": "NODE_OPTIONS='--inspect' next dev",
     "watch": "concurrently --raw \"bsb -make-world -w\" \"next dev\" ",
-    "build": "bsb -clean-world -make-world && next build && yarn total-dependencies-check",
+    "build": "bsb -clean-world -make-world && next build && yarn total-dependencies-check && next export",
     "start-test-server": "next start",
     "total-dependencies-check": "(test $(grep '^[a-zA-Z@].*:$' yarn.lock | wc -l) -lt 500 && echo ok) || (echo too many deps && exit 1) "
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "next:debug": "NODE_OPTIONS='--inspect' next dev",
     "watch": "concurrently --raw \"bsb -make-world -w\" \"next dev\" ",
     "build": "bsb -clean-world -make-world && next build && yarn total-dependencies-check && next export",
-    "start-test-server": "next start",
     "total-dependencies-check": "(test $(grep '^[a-zA-Z@].*:$' yarn.lock | wc -l) -lt 500 && echo ok) || (echo too many deps && exit 1) "
   },
   "scriptsDescription": {

--- a/src/GlobalData.res
+++ b/src/GlobalData.res
@@ -66,7 +66,7 @@ let navContentEn = {
     },
     packages: {
       label: `Packages`,
-      url: "http://ci5.ocamllabs.io:8082/" /* TODO - point to correct page once it's created */,
+      url: "/packages",
       icon: Icons.packages,
       text: "Browse the third-party packages published in the OCaml ecosystem.",
     },


### PR DESCRIPTION
As per our discussions, the prefered deployment solution that integrates well with v3.ocaml.org and the doc site is to export v3.ocaml.org as static files.

This PR:

- Adds a dockerfile that builds the site and export it. The last stage of the docker file contains only the exported file in `/app` so this can be exported easily by e.g. an ocurrent pipeline. It also exposed them as a web server, so running `docker run -p 3000:3000 v3.ocaml.org` will serve the application.
- Add a `trailingSlash: true` configuration to make the routing and redirects work with the exported application
- Change the package URL to `/packages`. The packages static files can be uploaded to the `packages/` subdirectory of the website for the integration to work.
- Add a Github action workflow that builds and publish the docker image

cc @avsm I'm not sure what we prefer: to build the dockerfile from the ocurrent pipeline, or download it from the docker hub. If we choose the later, could we add the `DOCKERHUB_TOKEN` and `DOCKERHUB_USERNAME` secrets to the repo, to allow the GitHub action to push the images to DockerHub?