### PR TITLE
add tutorials to language page and create SplitCard component

### DIFF
--- a/pages/[lang]/community/aroundweb.res
+++ b/pages/[lang]/community/aroundweb.res
@@ -63,61 +63,56 @@ module T = {
     }
 
     @react.component
-    let make = (~content, ~lang) =>
-      <SectionContainer.LargeCentered>
-        <div className="relative bg-white">
-          <div className="pt-12 h-56 sm:h-72 md:absolute md:left-0 md:h-full md:w-1/2">
-            <div className="mx-auto px-4 py-4 sm:px-6 lg:px-8 lg:py-16 h-full">
-              // TODO: Implement the calendar approach
-              <div className="flex flex-col justify-center h-full">
-                {content.latestEvents
-                |> Array.mapi((idx, event: Ood.Event.t) =>
-                  <div key={event.title}>
-                    <div className="relative pb-8">
-                      {idx !== Array.length(content.latestEvents) - 1
-                        ? <span
-                            className="absolute top-3 left-3 -ml-px h-full w-0.5 bg-gray-200"
-                            ariaHidden=true
-                          />
-                        : <> </>}
-                      <div className="relative flex space-x-3">
-                        <div>
-                          <span
-                            className="h-6 w-6 rounded-full flex items-center justify-center bg-orangedark"
-                          />
-                        </div>
-                        <div className="min-w-0 flex-1 pt-1.5 flex justify-between space-x-4">
-                          <div> <p className="text-sm text-gray-500"> {s(event.title)} </p> </div>
-                          <div className="text-right text-sm whitespace-nowrap text-gray-500">
-                            <time dateTime={event.date}>
-                              {s(event.date |> Js.Date.fromString |> Js.Date.toDateString)}
-                            </time>
-                          </div>
-                        </div>
+    let make = (~content, ~lang) => {
+      let right =
+        <div className="flex h-full pb-8 sm:pb-0 items-center justify-center">
+          <div>
+            {content.latestEvents
+            |> Array.mapi((idx, event: Ood.Event.t) =>
+              <div key={event.title}>
+                <div className="relative pb-3">
+                  {idx !== Array.length(content.latestEvents) - 1
+                    ? <span
+                        className="absolute top-3 left-3 -ml-px h-full w-0.5 bg-gray-200"
+                        ariaHidden=true
+                      />
+                    : <> </>}
+                  <div className="relative flex space-x-3">
+                    <div>
+                      <span
+                        className="h-6 w-6 rounded-full flex items-center justify-center bg-orangedark"
+                      />
+                    </div>
+                    <div className="min-w-0 flex-1 pt-1.5 flex justify-between space-x-4">
+                      <div> <p className="text-sm text-gray-500"> {s(event.title)} </p> </div>
+                      <div className="text-right text-sm whitespace-nowrap text-gray-500">
+                        <time dateTime={event.date}>
+                          {s(event.date |> Js.Date.fromString |> Js.Date.toDateString)}
+                        </time>
                       </div>
                     </div>
                   </div>
-                )
-                |> React.array}
+                </div>
               </div>
-            </div>
-          </div>
-          // TODO: understand how the maxWidth works together with relative
-          <div className="relative max-w-7xl mx-auto px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
-            // TODO: understand how md:w-1/2 works together with relative
-            <div className="md:ml-auto md:w-1/2 md:pl-10">
-              <CallToAction.Embedded
-                t={
-                  CallToAction.title: content.title,
-                  body: content.description,
-                  buttonLink: Route(#communityEvents, lang),
-                  buttonText: content.callToAction,
-                }
-              />
-            </div>
+            )
+            |> React.array}
           </div>
         </div>
-      </SectionContainer.LargeCentered>
+      let left =
+        <div className="flex h-full flex-col items-center justify-center">
+          <div className="py-8 sm:pl-12">
+            <CallToAction.Embedded
+              t={
+                CallToAction.title: content.title,
+                body: content.description,
+                buttonLink: Route(#communityEvents, lang),
+                buttonText: content.callToAction,
+              }
+            />
+          </div>
+        </div>
+      <SplitCard.LargeCentered left right />
+    }
   }
 
   module Space = {

--- a/pages/[lang]/resources/language.res
+++ b/pages/[lang]/resources/language.res
@@ -3,6 +3,47 @@ open! Import
 let s = React.string
 
 module T = {
+  module Tutorials = {
+    type t = {
+      title: string,
+      description: string,
+      tutorials: array<Ood.Tutorial.t>,
+    }
+
+    @react.component
+    let make = (~content, ~lang) => {
+      let left =
+        <div className="flex h-full flex-col items-center justify-center">
+          <div className="py-8 sm:pl-12">
+            <CallToAction.Embedded
+              t={
+                CallToAction.title: content.title,
+                body: content.description,
+                buttonLink: Route(#resourcesTutorials, lang),
+                buttonText: "See All Tutorials",
+              }
+            />
+          </div>
+        </div>
+
+      let right =
+        <div className="flex h-full items-center justify-center">
+          <ul className="list-disc pb-8 sm:pb-0 leading-10">
+            {Array.map(
+              (t: Ood.Tutorial.t) =>
+                <li>
+                  <Route _to={#resourcesTutorial(t.slug)} lang>
+                    <a className="text-orangedark text-xl underline"> {s(t.title)} </a>
+                  </Route>
+                </li>,
+              content.tutorials,
+            ) |> React.array}
+          </ul>
+        </div>
+      <SplitCard.MediumCentered left right />
+    }
+  }
+
   module UserLevelIntroduction = {
     type t = {
       level: string,
@@ -29,81 +70,85 @@ module T = {
     let make = (~marginBottom=?, ~content) =>
       // TODO: define content type; extract content
       // TODO: use generic container
-      <div
-        className={"bg-white overflow-hidden shadow rounded-lg mx-auto max-w-5xl " ++
-        Tailwind.MarginBottomByBreakpoint.toClassNamesOrEmpty(marginBottom)}>
-        <div className="px-4 py-5 sm:px-6 sm:py-9">
-          <h2 className="text-center text-orangedark text-7xl font-bold mb-8 uppercase">
-            {s(content.booksLabel)}
-          </h2>
-          <div className="grid grid-cols-8 items-center mb-8 px-6">
-            // TODO: define state to track location within books list, activate navigation
-            <div className="flex justify-start">
-              // TODO: make navigation arrows accesssible
-              <svg
-                className="h-20"
-                viewBox="0 0 90 159"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg">
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M2.84806 86.0991L72.1515 155.595C76.1863 159.39 82.3571 159.39 86.1546 155.595C89.952 151.8 89.952 145.396 86.1546 141.601L23.734 79.2206L86.1546 16.8403C89.952 12.8081 89.952 6.64125 86.1546 2.84625C82.3571 -0.94875 76.1863 -0.94875 72.1515 2.84625L2.84806 72.105C-0.949387 76.1372 -0.949387 82.3041 2.84806 86.0991Z"
-                  fill="#ED7109"
-                />
-              </svg>
-            </div>
-            <div className="col-span-6 flex justify-center">
-              <ul
-                role="list"
-                className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-6">
-                {content.books
-                |> Js.Array.mapi((book: Ood.Book.t, idx) => {
-                  let cover = Belt.Option.getWithDefault(book.cover, "")
+      <SectionContainer.LargeCentered paddingY="pt-16 pb-3 lg:pt-24 lg:pb-8">
+        <div
+          className={"bg-white overflow-hidden shadow rounded-lg mx-auto max-w-5xl " ++
+          Tailwind.MarginBottomByBreakpoint.toClassNamesOrEmpty(marginBottom)}>
+          <div className="px-4 py-5 sm:px-6 sm:py-9">
+            <h2 className="text-center text-orangedark text-7xl font-bold mb-8 uppercase">
+              {s(content.booksLabel)}
+            </h2>
+            <div className="grid grid-cols-8 items-center mb-8 px-6">
+              // TODO: define state to track location within books list, activate navigation
+              <div className="flex justify-start">
+                // TODO: make navigation arrows accesssible
+                <svg
+                  className="h-20"
+                  viewBox="0 0 90 159"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                    d="M2.84806 86.0991L72.1515 155.595C76.1863 159.39 82.3571 159.39 86.1546 155.595C89.952 151.8 89.952 145.396 86.1546 141.601L23.734 79.2206L86.1546 16.8403C89.952 12.8081 89.952 6.64125 86.1546 2.84625C82.3571 -0.94875 76.1863 -0.94875 72.1515 2.84625L2.84806 72.105C-0.949387 76.1372 -0.949387 82.3041 2.84806 86.0991Z"
+                    fill="#ED7109"
+                  />
+                </svg>
+              </div>
+              <div className="col-span-6 flex justify-center">
+                <ul
+                  role="list"
+                  className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-6">
+                  {content.books
+                  |> Js.Array.mapi((book: Ood.Book.t, idx) => {
+                    let cover = Belt.Option.getWithDefault(book.cover, "")
 
-                  <li title={book.title} key={Js.Int.toString(idx)} className="relative">
-                    <div
-                      className="block w-full aspect-w7 aspect-h-10 rounded-lg bg-gray-100 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-gray-100 focus-within:ring-indigo-500 overflow-hidden">
-                      <img src=cover alt="" className="object-cover" />
-                    </div>
-                    <p className="mt-2 block text-sm font-medium text-gray-900 truncate">
-                      {s(book.title)}
-                    </p>
-                    <p className="block text-sm font-medium text-gray-500">
-                      {book.links
-                      |> List.mapi((
-                        _idx,
-                        link: Ood.Book.link,
-                      ) => // TODO: visual indicator that link opens new tab
-                      <>
-                        <a href=link.uri target="_blank"> <span> {s(link.description)} </span> </a>
-                        <span className="inline-block px-2"> {s("|")} </span>
-                      </>)
-                      |> Array.of_list
-                      |> React.array}
-                    </p>
-                  </li>
-                })
-                |> React.array}
-              </ul>
-            </div>
-            <div className="flex justify-end">
-              <svg
-                className="h-20"
-                viewBox="0 0 90 159"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg">
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M86.1546 72.3423L16.8512 2.84625C12.8164 -0.948746 6.64553 -0.948746 2.84809 2.84625C-0.949362 6.64127 -0.949362 13.0453 2.84809 16.8403L65.2686 79.2207L2.84809 141.601C-0.949362 145.633 -0.949362 151.8 2.84809 155.595C6.64553 159.39 12.8164 159.39 16.8512 155.595L86.1546 86.3363C89.952 82.3041 89.952 76.1373 86.1546 72.3423Z"
-                  fill="#ED7109"
-                />
-              </svg>
+                    <li title={book.title} key={Js.Int.toString(idx)} className="relative">
+                      <div
+                        className="block w-full aspect-w7 aspect-h-10 rounded-lg bg-gray-100 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-gray-100 focus-within:ring-indigo-500 overflow-hidden">
+                        <img src=cover alt="" className="object-cover" />
+                      </div>
+                      <p className="mt-2 block text-sm font-medium text-gray-900 truncate">
+                        {s(book.title)}
+                      </p>
+                      <p className="block text-sm font-medium text-gray-500">
+                        {book.links
+                        |> List.mapi((
+                          _idx,
+                          link: Ood.Book.link,
+                        ) => // TODO: visual indicator that link opens new tab
+                        <>
+                          <a href=link.uri target="_blank">
+                            <span> {s(link.description)} </span>
+                          </a>
+                          <span className="inline-block px-2"> {s("|")} </span>
+                        </>)
+                        |> Array.of_list
+                        |> React.array}
+                      </p>
+                    </li>
+                  })
+                  |> React.array}
+                </ul>
+              </div>
+              <div className="flex justify-end">
+                <svg
+                  className="h-20"
+                  viewBox="0 0 90 159"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                    d="M86.1546 72.3423L16.8512 2.84625C12.8164 -0.948746 6.64553 -0.948746 2.84809 2.84625C-0.949362 6.64127 -0.949362 13.0453 2.84809 16.8403L65.2686 79.2207L2.84809 141.601C-0.949362 145.633 -0.949362 151.8 2.84809 155.595C6.64553 159.39 12.8164 159.39 16.8512 155.595L86.1546 86.3363C89.952 82.3041 89.952 76.1373 86.1546 72.3423Z"
+                    fill="#ED7109"
+                  />
+                </svg>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </SectionContainer.LargeCentered>
   }
 
   module Manual = {
@@ -249,6 +294,7 @@ module T = {
   type t = {
     title: string,
     pageDescription: string,
+    tutorials: Tutorials.t,
     beginning: UserLevelIntroduction.t,
     growing: UserLevelIntroduction.t,
     booksContent: Books.t,
@@ -276,8 +322,7 @@ module T = {
         addContainer=Page.Basic.NoContainer
         title=content.title
         pageDescription=content.pageDescription>
-        <UserLevelIntroduction content=content.beginning marginBottom=introMarginBottom />
-        <UserLevelIntroduction content=content.growing marginBottom=introMarginBottom />
+        <Tutorials content=content.tutorials lang />
         <Books marginBottom={Tailwind.ByBreakpoint.make(#mb16, ())} content=content.booksContent />
         <UserLevelIntroduction content=content.expanding marginBottom=introMarginBottom />
         <Manual marginBottom={Tailwind.ByBreakpoint.make(#mb20, ())} />
@@ -291,10 +336,16 @@ module T = {
 
   let contentEn = {
     let books = Ood.Book.all->Belt.List.toArray
+    let tutorials = Belt.List.keepWithIndex(Ood.Tutorial.all, (_, i) => i < 4)->Belt.List.toArray
     // TODO: read book sorting and filtering information and adjust array
     {
       title: `Language`,
       pageDescription: `This is the home of learning and tutorials. Whether you're a beginner, a teacher, or a seasoned researcher, this is where you can find the resources you need to accomplish your goals in OCaml.`,
+      tutorials: {
+        title: `OCaml Tutorials`,
+        description: `There are plenty of tutorials available for you to get started with OCaml, written by dedicated members of the community. Take a look and see what you can discover.`,
+        tutorials: tutorials,
+      },
       beginning: {
         level: `Beginning`,
         introduction: `Are you a beginner? Or just someone who wants to brush up on the fundamentals? In either case, the OFronds tutorial system has you covered!`,

--- a/pages/[lang]/resources/language.resi
+++ b/pages/[lang]/resources/language.resi
@@ -5,6 +5,14 @@ module UserLevelIntroduction: {
   }
 }
 
+module Tutorials: {
+  type t = {
+    title: string,
+    description: string,
+    tutorials: array<Ood.Tutorial.t>,
+  }
+}
+
 module Books: {
   type t = {
     booksLabel: string,
@@ -15,6 +23,7 @@ module Books: {
 type t = {
   title: string,
   pageDescription: string,
+  tutorials: Tutorials.t,
   beginning: UserLevelIntroduction.t,
   growing: UserLevelIntroduction.t,
   booksContent: Books.t,

--- a/pages/[lang]/resources/tutorials.res
+++ b/pages/[lang]/resources/tutorials.res
@@ -1,0 +1,56 @@
+open! Import
+
+// TODO: A design for this page, this is just a placeholder
+
+let s = React.string
+
+module Tutorial = {
+  @react.component
+  let make = (~tutorial, ~lang) =>
+    <div className="py-4 px-4 bg-white rounded-lg">
+      <div className="prose">
+        <h2> {s(tutorial.Ood.Tutorial.title)} </h2> <p> {s(tutorial.description)} </p>
+      </div>
+      <Route _to={#resourcesTutorial(tutorial.slug)} lang>
+        <a className="text-orangedark"> {s("Read more...")} </a>
+      </Route>
+    </div>
+}
+
+module T = {
+  type t = {
+    title: string,
+    pageDescription: string,
+    tutorials: array<Ood.Tutorial.t>,
+  }
+
+  module Params = Pages.Params.Lang
+
+  @react.component
+  let make = (~content, ~params as {Params.lang: lang}) => {
+    <>
+      <ConstructionBanner />
+      <Page.Basic title=content.title pageDescription=content.pageDescription>
+        <div className="pb-8">
+          <CardGrid
+            cardData=content.tutorials
+            renderCard={(t: Ood.Tutorial.t) => <Tutorial tutorial=t lang />}
+          />
+        </div>
+      </Page.Basic>
+    </>
+  }
+
+  include Jsonable.Unsafe
+
+  let contentEn = {
+    title: `Tutorials`,
+    pageDescription: ``,
+    tutorials: Ood.Tutorial.all->Belt.List.toArray,
+  }
+
+  let content = [({Params.lang: #en}, contentEn)]
+}
+
+include T
+include Pages.MakeSimple(T)

--- a/pages/[lang]/resources/tutorials.resi
+++ b/pages/[lang]/resources/tutorials.resi
@@ -1,0 +1,7 @@
+type t = {
+  title: string,
+  pageDescription: string,
+  tutorials: array<Ood.Tutorial.t>,
+}
+
+include Pages.S with type t := t

--- a/src/CardGrid.res
+++ b/src/CardGrid.res
@@ -10,7 +10,7 @@ let make = (~cardData, ~renderCard, ~title=?, ()) => <>
     </h2>
   | None => <> </>
   }}
-  <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-40 gap-y-4 px-8">
+  <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-28 gap-y-4 px-8">
     {cardData->Belt.Array.map(renderCard)->React.array}
   </div>
 </>

--- a/src/Route.res
+++ b/src/Route.res
@@ -29,6 +29,8 @@ type t = [
   | #resourcesPlatform
   | #resourcesReleases
   | #resourcesUsingocaml
+  | #resourcesTutorials
+  | #resourcesTutorial(string)
 ]
 
 let toString = (t: t, lang) => {
@@ -62,6 +64,8 @@ let toString = (t: t, lang) => {
   | #resourcesPlatform => "resources/platform"
   | #resourcesReleases => "resources/releases"
   | #resourcesUsingocaml => "resources/usingocaml"
+  | #resourcesTutorials => "resources/tutorials"
+  | #resourcesTutorial(s) => "resources/" ++ s
   }
   "/" ++ lang ++ "/" ++ path
 }

--- a/src/Route.resi
+++ b/src/Route.resi
@@ -29,6 +29,8 @@ type t = [
   | #resourcesPlatform
   | #resourcesReleases
   | #resourcesUsingocaml
+  | #resourcesTutorials
+  | #resourcesTutorial(string)
 ]
 
 let toString: (t, Lang.t) => string

--- a/src/SplitCard.res
+++ b/src/SplitCard.res
@@ -1,0 +1,19 @@
+module LargeCentered = {
+  @react.component
+  let make = (~left: React.element, ~right: React.element) =>
+    <SectionContainer.LargeCentered>
+      <div className="grid gird-cols-1 sm:grid-cols-2 gap-4 bg-white ">
+        <div> {left} </div> <div> {right} </div>
+      </div>
+    </SectionContainer.LargeCentered>
+}
+
+module MediumCentered = {
+  @react.component
+  let make = (~left: React.element, ~right: React.element) =>
+    <SectionContainer.MediumCentered>
+      <div className="grid gird-cols-1 sm:grid-cols-2 gap-4 bg-white ">
+        <div> {left} </div> <div> {right} </div>
+      </div>
+    </SectionContainer.MediumCentered>
+}

--- a/src/SplitCard.resi
+++ b/src/SplitCard.resi
@@ -1,0 +1,11 @@
+// A split card has a left and right component of equal sizes
+
+module LargeCentered: {
+  @react.component
+  let make: (~left: React.element, ~right: React.element) => React.element
+}
+
+module MediumCentered: {
+  @react.component
+  let make: (~left: React.element, ~right: React.element) => React.element
+}


### PR DESCRIPTION
### Changes

 - Added a tutorial call-to-action style component to the language page
 - Added a simple tutorial index page linking to all of the tutorials
 - Implemented a `SplitCard` component that is used on the language page and the events page (at the moment)
 
### Discussion

This PR adds access to the tutorials we now have in ood. It partially completes #186 but the design is not identical. I was in favour of trying to converge on a common set of components by implementing a `SplitCard` component which I have then reused over on the events page too (which hopefully proves its usefulness). 

The tutorial index page is incredibly simple, and just reuses the `CardGrid`, we'll probably want to redesign this page (I don't believe we have a design just for it) to make use of the proficiency levels and tags for better organisation. But for now I'm just in favour of getting a "clickable" way to get to any of the tutorials :)) 

### Screenshots 

The call to action section of the language page, it just displays the first few tutorials and then links to the index. 

<img width="1432" alt="Tutorial call to action" src="https://user-images.githubusercontent.com/20166594/126678098-c875f07c-7c21-4b3f-8bb4-b22dfc0a04ee.png">

The index page for the tutorials, nothing fancy 😅 

<img width="1434" alt="Tutorial index page" src="https://user-images.githubusercontent.com/20166594/126678145-b0001756-8a0b-4af7-b638-9616fe39c052.png">
