### PR TITLE
refactor: drop ResourcesBasics

### DIFF
--- a/src/Route.res
+++ b/src/Route.res
@@ -17,7 +17,6 @@ type t = [
   | #LegalCarbonfootprint
   | #LegalPrivacy
   | #LegalTerms
-  | #ResourcesBasics
   | #ResourcesInstallocaml
   | #ResourcesApplications
   | #ResourcesArchive
@@ -52,7 +51,6 @@ let toString = (t: t, lang) => {
   | #LegalCarbonfootprint => "legal/carbonfootprint"
   | #LegalPrivacy => "legal/privacy"
   | #LegalTerms => "legal/terms"
-  | #ResourcesBasics => "resources/basics"
   | #ResourcesInstallocaml => "resources/installocaml"
   | #ResourcesApplications => "resources/applications"
   | #ResourcesArchive => "resources/archive"

--- a/src/Route.res
+++ b/src/Route.res
@@ -51,7 +51,7 @@ let toString = (t: t, lang) => {
   | #LegalCarbonfootprint => "legal/carbonfootprint"
   | #LegalPrivacy => "legal/privacy"
   | #LegalTerms => "legal/terms"
-  | #ResourcesInstallocaml => "resources/installocaml"
+  | #ResourcesInstallocaml => "resources/tutorials/up-and-running-with-ocaml/#installing-ocaml"
   | #ResourcesApplications => "resources/applications"
   | #ResourcesArchive => "resources/archive"
   | #ResourcesBestpractices => "resources/bestpractices"

--- a/src/Route.resi
+++ b/src/Route.resi
@@ -17,7 +17,6 @@ type t = [
   | #LegalCarbonfootprint
   | #LegalPrivacy
   | #LegalTerms
-  | #ResourcesBasics
   | #ResourcesInstallocaml
   | #ResourcesApplications
   | #ResourcesArchive


### PR DESCRIPTION
<!-- Brief description of purpose of changes and what changed -->
# Problems

- link incorrect for installation
- unused route

# Solutions

- corrected pathname for installation
- drop unused route

Closes #490

## Modified relative paths:

<!-- For local branches, replace "BRANCH_NAME" with your branch; replace PATH/TO/PAGE -->
https://v3-ocaml-org-git-fork-cdaringe-refactor-home-ocaml.vercel.app/

<!-- For branches in forks, replace "FORK_NAME" and "BRANCH_NAME" with appropriate values, replace PATH/TO/PAGE -->
<!-- https://v3-ocaml-org-git-fork-FORK_NAME-BRANCH_NAME-ocaml.vercel.app/PATH/TO/PAGE -->

## Contributor Pre-flight Checklist

- [x] Accessibility check - checked pa11y report for modified pages, observing new errors
- [x] Responsive check - visually inspected vercel preview, using responsive tool to toggle between desktop and mobile view
- [x] HTML review - use browser DOM/Page inspector to inspect generated HTML within `<div id="__next>"` element
