### PR TITLE
Rename tutorial Param to Slug

### DIFF
--- a/pages/[lang]/resources/tutorials/[tutorial].res
+++ b/pages/[lang]/resources/tutorials/[tutorial].res
@@ -9,12 +9,14 @@ module T = {
   }
   include Jsonable.Unsafe
 
-  module Params = Pages.Params.Lang.Tutorial
+  module Params = Pages.Params.Lang.Slug({
+    let name = "tutorial"
+  })
 
   @react.component
   let make = (
     ~content as {source, title, pageDescription, tableOfContents},
-    ~params as {Params.lang: _, tutorial: _},
+    ~params as {Params.lang: _, slug: _},
   ) => {
     <>
       // TODO: should this have a constrained width? what does tailwind do?
@@ -39,7 +41,7 @@ module T = {
       {Ood.Tutorial.slug: slug, body_html, title, description, toc_html}: Ood.Tutorial.t,
     ) => {
       (
-        {Params.lang: #en, tutorial: slug},
+        {Params.lang: #en, slug: slug},
         {
           source: body_html,
           title: title,

--- a/src/Pages.resi
+++ b/src/Pages.resi
@@ -7,8 +7,11 @@ module Params: {
     type t = {lang: Lang.t}
     include S with type t := t
 
-    module Tutorial: {
-      type t = {lang: Lang.t, tutorial: string}
+    module Slug: {
+      let name: string
+    } =>
+    {
+      type t = {lang: Lang.t, slug: string}
       include S with type t := t
     }
   }
@@ -18,12 +21,13 @@ module type S = {
   type t
   type props<'content, 'params>
   type params
+  type json1<'a> = Js.Json.t
 
   @react.component
   let make: (~content: t, ~params: params) => React.element
 
-  let getStaticProps: Next.GetStaticProps.t<props<t, params>, params, void>
-  let getStaticPaths: Next.GetStaticPaths.t<params>
+  let getStaticProps: Next.GetStaticProps.t<props<t, params>, json1<params>, void>
+  let getStaticPaths: Next.GetStaticPaths.t<json1<params>>
   let default: props<Js.Json.t, Js.Json.t> => React.element
 }
 


### PR DESCRIPTION
Issue: #458 

CHANGES:
- Change Pages.Params.Lang.Tutorial to Pages.Params.Lang.Slug, and make it configurable with any slug title