### PR TITLE
feat: add-basic-github-actions-ci

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,25 @@
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#on
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ["14"]
+    name: Node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "npm"
+          cache-dependency-path: yarn.lock
+      - run: make install-deps
+      - run: make build


### PR DESCRIPTION
## Problem

No CI is currently run in PRs

## Solution

Run some CI! Stub in barebones `build & install` steps. These are untested :)

## Modified relative paths:

<!-- For local branches, replace "BRANCH_NAME" with your branch; replace PATH/TO/PAGE -->
https://v3-ocaml-org-git-BRANCH_NAME-ocaml.vercel.app/PATH/TO/PAGE

<!-- For branches in forks, replace "FORK_NAME" and "BRANCH_NAME" with appropriate values, replace PATH/TO/PAGE -->
https://v3-ocaml-org-git-fork-FORK_NAME-BRANCH_NAME-ocaml.vercel.app/PATH/TO/PAGE

## Contributor Pre-flight Checklist

- [ ] Accessibility check - checked pa11y report for modified pages, observing new errors
- [ ] Responsive check - visually inspected vercel preview, using responsive tool to toggle between desktop and mobile view
- [ ] HTML review - use browser DOM/Page inspector to inspect generated HTML within `<div id="__next>"` element
